### PR TITLE
fix: PSB-01

### DIFF
--- a/contracts/pre-launch-event/PlaybuxSBT.sol
+++ b/contracts/pre-launch-event/PlaybuxSBT.sol
@@ -146,10 +146,9 @@ contract PlaybuxSBT is ERC721, IERC5192, ERC721Enumerable, AccessControl {
 
     /**
      * @dev to comply with ERC5192
-     * @param _tokenId uint256 ID of the token to query
-     * @return uint256 status of the token
+     * @return bool status of the token
      */
-    function locked(uint256 _tokenId) external view override(IERC5192) returns (bool) {
+    function locked(uint256) external pure override(IERC5192) returns (bool) {
         return true; // all tokens are locked
     }
 


### PR DESCRIPTION
Some protocols might check whether the token was locked or not with the ERC5192 standard, so we need to implement this function to comply with them, and in our case, this function will always return true because we fixed all token ids to soulbound tokens.

and we've changed function visibility of this function from `view` to `pure`